### PR TITLE
change `issubclass` to `isinstance`

### DIFF
--- a/lingam/var_lingam.py
+++ b/lingam/var_lingam.py
@@ -76,7 +76,7 @@ class VARLiNGAM:
         lingam_model = self._lingam_model
         if lingam_model is None:
             lingam_model = DirectLiNGAM()
-        elif not issubclass(lingam_model, _BaseLiNGAM):
+        elif not isinstance(lingam_model, _BaseLiNGAM):
             raise ValueError('lingam_model must be a subclass of _BaseLiNGAM')
 
         M_taus = self._ar_coefs

--- a/lingam/varma_lingam.py
+++ b/lingam/varma_lingam.py
@@ -84,7 +84,7 @@ class VARMALiNGAM:
         lingam_model = self._lingam_model
         if lingam_model is None:
             lingam_model = DirectLiNGAM()
-        elif not issubclass(lingam_model, _BaseLiNGAM):
+        elif not isinstance(lingam_model, _BaseLiNGAM):
             raise ValueError('lingam_model must be a subclass of _BaseLiNGAM')
 
         phis = self._ar_coefs


### PR DESCRIPTION
Hi,

Thank you so much for providing this helpful LINGAM package. I was looking at how to use ICA-LINAM with VAR-LINGAM. However, the code throws errors when I do so:
`ICALiNGAM_model = lingam.ICALiNGAM()`
`VARLiNGAM_model = lingam.VARLiNGAM(lags=1, lingam_model=ICALiNGAM_model)`
One way to fix it is to change `issubclass` to `isinstance`.

Thank you very much.