### PR TITLE
Fix numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<1.23.5
+numpy
 scipy
 scikit-learn
 graphviz

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description=README,
     long_description_content_type='text/markdown',
     install_requires=[
-        'numpy<1.23.5',
+        'numpy,
         'scipy',
         'scikit-learn',
         'graphviz',


### PR DESCRIPTION
Since pygam no longer uses np.int in v0.9, numpy version fixing is no longer necessary.
https://github.com/dswah/pyGAM/releases/tag/v0.9.0