### PR TITLE
Accelerate DirectLiNGAM by parallelising causal ordering on GPUs with CUDA

### DIFF
--- a/examples/DirectLiNGAM_fast.py
+++ b/examples/DirectLiNGAM_fast.py
@@ -32,25 +32,22 @@ def main():
         X = pd.DataFrame(np.array([x0, x1, x2, x3, x4, x5]).T ,columns=['x0', 'x1', 'x2', 'x3', 'x4', 'x5'])
         X.head()
 
-
-        m = np.array([[0.0, 0.0, 0.0, 3.0, 0.0, 0.0],
-                    [3.0, 0.0, 2.0, 0.0, 0.0, 0.0],
-                    [0.0, 0.0, 0.0, 6.0, 0.0, 0.0],
-                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-                    [8.0, 0.0,-1.0, 0.0, 0.0, 0.0],
-                    [4.0, 0.0, 0.0, 0.0, 0.0, 0.0]])
-
         # ## Causal Discovery
         # To run causal discovery, we create a `DirectLiNGAM` object and call the `fit` method.
         # We use the pwling_fast measure which uses a CUDA accelerated implementation of pwling
 
-        model = lingam.DirectLiNGAM(measure='pwling_fast')
+        model = lingam.DirectLiNGAM(measure='pwling')
         model.fit(X)
 
         print(model.causal_order_)
         print(model.adjacency_matrix_)
 
-        make_dot(model.adjacency_matrix_)
+        m = model.adjacency_matrix_
+
+        model = lingam.DirectLiNGAM(measure='pwling_fast')
+        model.fit(X)
+
+        assert np.allclose(model.adjacency_matrix_, m)
 
         # ## Independence between error variables
         # To check if the LiNGAM assumption is broken, we can get p-values of independence between error variables. The value in the i-th row and j-th column of the obtained matrix shows the p-value of the independence of the error variables $e_i$ and $e_j$.

--- a/examples/DirectLiNGAM_fast.py
+++ b/examples/DirectLiNGAM_fast.py
@@ -1,0 +1,62 @@
+import sys
+import os
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+
+import numpy as np
+import pandas as pd
+import graphviz
+import lingam
+from lingam.utils import make_dot, get_cuda_version
+
+def main():
+    cuda = get_cuda_version()
+
+    if cuda:
+        print([np.__version__, pd.__version__, graphviz.__version__, lingam.__version__])
+
+        np.set_printoptions(precision=3, suppress=True)
+        np.random.seed(100)
+
+        # ## Test data
+        # We create test data consisting of 6 variables.
+
+        x3 = np.random.uniform(size=1000)
+        x0 = 3.0*x3 + np.random.uniform(size=1000)
+        x2 = 6.0*x3 + np.random.uniform(size=1000)
+        x1 = 3.0*x0 + 2.0*x2 + np.random.uniform(size=1000)
+        x5 = 4.0*x0 + np.random.uniform(size=1000)
+        x4 = 8.0*x0 - 1.0*x2 + np.random.uniform(size=1000)
+        X = pd.DataFrame(np.array([x0, x1, x2, x3, x4, x5]).T ,columns=['x0', 'x1', 'x2', 'x3', 'x4', 'x5'])
+        X.head()
+
+
+        m = np.array([[0.0, 0.0, 0.0, 3.0, 0.0, 0.0],
+                    [3.0, 0.0, 2.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 6.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [8.0, 0.0,-1.0, 0.0, 0.0, 0.0],
+                    [4.0, 0.0, 0.0, 0.0, 0.0, 0.0]])
+
+        # ## Causal Discovery
+        # To run causal discovery, we create a `DirectLiNGAM` object and call the `fit` method.
+        # We use the pwling_fast measure which uses a CUDA accelerated implementation of pwling
+
+        model = lingam.DirectLiNGAM(measure='pwling_fast')
+        model.fit(X)
+
+        print(model.causal_order_)
+        print(model.adjacency_matrix_)
+
+        make_dot(model.adjacency_matrix_)
+
+        # ## Independence between error variables
+        # To check if the LiNGAM assumption is broken, we can get p-values of independence between error variables. The value in the i-th row and j-th column of the obtained matrix shows the p-value of the independence of the error variables $e_i$ and $e_j$.
+
+        p_values = model.get_error_independence_p_values(X)
+        print(p_values)
+
+if __name__ == "__main__":
+    main()

--- a/lingam/direct_lingam.py
+++ b/lingam/direct_lingam.py
@@ -8,6 +8,7 @@ from sklearn.preprocessing import scale
 from sklearn.utils import check_array
 
 from .base import _BaseLiNGAM
+from lingam_cuda import causal_order as causal_order_gpu
 
 
 class DirectLiNGAM(_BaseLiNGAM):
@@ -45,7 +46,7 @@ class DirectLiNGAM(_BaseLiNGAM):
             * ``-1`` : No prior knowledge is available to know if either of the two cases above (0 or 1) is true.
         apply_prior_knowledge_softly : boolean, optional (default=False)
             If True, apply prior knowledge softly.
-        measure : {'pwling', 'kernel'}, optional (default='pwling')
+        measure : {'pwling', 'kernel', 'pwling_fast'}, optional (default='pwling')
             Measure to evaluate independence: 'pwling' [2]_ or 'kernel' [1]_.
         """
         super().__init__(random_state)
@@ -96,6 +97,8 @@ class DirectLiNGAM(_BaseLiNGAM):
         for _ in range(n_features):
             if self._measure == "kernel":
                 m = self._search_causal_order_kernel(X_, U)
+            elif self._measure == "pwling_fast":
+                m = self._search_causal_order_gpu(X_.astype(np.float64), U.astype(np.int32))
             else:
                 m = self._search_causal_order(X_, U)
             for i in U:
@@ -232,6 +235,29 @@ class DirectLiNGAM(_BaseLiNGAM):
                     M += np.min([0, self._diff_mutual_info(xi_std, xj_std, ri_j, rj_i)]) ** 2
             M_list.append(-1.0 * M)
         return Uc[np.argmax(M_list)]
+
+    def _search_causal_order_gpu(self, X, U):
+        """Accelerated Causal ordering.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            Training data, where ``n_samples`` is the number of samples
+            and ``n_features`` is the number of features.
+        U: indices of cols in X
+
+        Returns
+        -------
+        self : object
+            Returns the instance itself.
+        mlist: causal ordering
+        """
+        cols = len(U)
+        rows = len(X)
+
+        arr = X[:, np.array(U)]
+        mlist = causal_order_gpu(arr, rows, cols)
+        return U[np.argmax(mlist)]
 
     def _mutual_information(self, x1, x2, param):
         """Calculate the mutual informations."""

--- a/lingam/utils/__init__.py
+++ b/lingam/utils/__init__.py
@@ -10,6 +10,8 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 import semopy
+import subprocess
+
 from matplotlib import colors as mcolors
 from matplotlib.colors import is_color_like
 from sklearn import linear_model
@@ -1128,3 +1130,12 @@ def calculate_total_effect(adjacency_matrix, from_index, to_index, is_continuous
     total_effect = sum(effects)
 
     return total_effect
+
+def get_cuda_version():
+    try:
+        nvcc_version = subprocess.check_output(["nvcc", "--version"]).decode('utf-8')
+        print("CUDA Version found:\n", nvcc_version)
+        return True
+    except Exception as e:
+        print("CUDA not found or nvcc not in PATH:", e)
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pygam
 matplotlib
 psy
 semopy
+#optional (install if gpu and cuda is available)
+# culingam==0.0.7


### PR DESCRIPTION
This PR includes the implementation drastically speed-up (up to 32x on consumer GPU) DirectLiNGAM and its variants e.g VarLiNGAM. 

The details are to allow for an optional dependency: https://github.com/Viktour19/culingam which implements custom CUDA kernels for the pairwise likelihood ratio causal ordering method.

The implementation has been tested locally on an NVIDIA RTX 6000 on a Linux machine - but tests on other setups are needed.