### PR TITLE
Fix RESIT edge elimination

### DIFF
--- a/lingam/resit.py
+++ b/lingam/resit.py
@@ -170,7 +170,7 @@ class RESIT(_BaseLiNGAM):
                 else:
                     residual = X[:, pi[k]]
                 # Measure dependence between residuals and {Xi}
-                _, hsic_p = hsic_test_gamma(residual, X[:, predictors+[l]])
+                _, hsic_p = hsic_test_gamma(residual, X[:, parents])
                 # eliminate edge
                 if hsic_p > self._alpha:
                     pa[pi[k]].remove(l)


### PR DESCRIPTION
In the current version of RESIT the independence of the residuals is not tested properly: the independence has to be tested between the residuals and *all* the potential parents, including 'l' (predictors + [l], line 173).

Also, when 'l' is the only potential parent, the algorithm should not exit the loop. Instead, it should test the independence between Xk and 'l' to ensure that 'l' can be excluded as a parent of Xk. Otherwise, it would not always be possible to recover causal graphs that are not connected, as the last 'l' is never removed from the parent set of Xk.

This update fixes both issues.