### PR TITLE
Fix m-LiNGAM bug for small sample size and improve documentation

### DIFF
--- a/docs/tutorial/missingness_lingam.rst
+++ b/docs/tutorial/missingness_lingam.rst
@@ -35,7 +35,7 @@ where :math:`i\in\{1,\dots,n\}\mapsto k(i)` denotes a causal order, and the non-
 The induced subgraph :math:`G[V_o \cup V_m \cup R]` follows a LiM model. The missingness mechanisms :math:`R_i \in R` follow a logistic model as for binary variables in LiM [4]_:
 
 .. math::
-    x_i = \mathbf 1\llbracket\sum_{k(j)<k(i)} b_{ij} x_j + e_i > 0\rrbracket, \qquad e_i \sim \text{Logistic}(0,1)
+    x_i = \mathbf 1[\sum_{k(j)<k(i)} b_{ij} x_j + e_i > 0], \qquad e_i \sim \text{Logistic}(0,1)
 
 
 Assumptions
@@ -49,6 +49,9 @@ The following assumptions are made to ensure identifiability:
 
 Note that even if self-masking is not allowed, indirect self-masking is: a partially observed variable can be an indirect cause (an ancestor) of its own missingness mechanism.
 Under these assumptions, m-LiNGAM guarantees identifiability of both the causal structure and parameters from observational data in the large-sample limit.
+
+Example
+^^^^^^^^^^^^^^^^^^
 
 An example Python notebook demonstrating m-LiNGAM is available `here <https://github.com/cdt15/lingam/blob/master/examples/MissingnessLiNGAM.ipynb>`__.
 

--- a/examples/MissingnessLiNGAM.ipynb
+++ b/examples/MissingnessLiNGAM.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "id": "cad9ee87",
    "metadata": {},
    "outputs": [
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "0b70fb17",
    "metadata": {},
    "outputs": [
@@ -54,12 +54,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Percentage of rows affected by missing data:  0.2988\n"
+      "Percentage of rows affected by missing data:  0.30718\n"
      ]
     }
    ],
    "source": [
-    "#Ex. 2 of MV-PCa\n",
+    "#Ex. 2 of MV-PC\n",
     "sample_size=50000\n",
     "logistic_scale=1.0\n",
     "B_true = np.array([[0,0,0,0],[1.1,0,0,0],[0,0.9,0,0],[0.8,0,1.2,0]])\n",
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "a9172d95",
    "metadata": {},
    "outputs": [
@@ -236,7 +236,7 @@
        "<title>0&#45;&gt;3</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M42.27,-74.73C52.01,-64.99 64.81,-52.19 75.79,-41.21\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"78.09,-43.86 82.68,-34.32 73.14,-38.91 78.09,-43.86\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"47.03\" y=\"-44.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.79</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"47.03\" y=\"-44.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.76</text>\r\n",
        "</g>\r\n",
        "<!-- 2 -->\r\n",
        "<g id=\"node3\" class=\"node\">\r\n",
@@ -249,14 +249,14 @@
        "<title>1&#45;&gt;2</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M114.27,-146.73C124.01,-136.99 136.81,-124.19 147.79,-113.21\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"150.09,-115.86 154.68,-106.32 145.14,-110.91 150.09,-115.86\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"119.03\" y=\"-116.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.88</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"119.03\" y=\"-116.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.86</text>\r\n",
        "</g>\r\n",
        "<!-- 2&#45;&gt;3 -->\r\n",
        "<g id=\"edge4\" class=\"edge\">\r\n",
        "<title>2&#45;&gt;3</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M155.73,-74.73C145.99,-64.99 133.19,-52.19 122.21,-41.21\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"124.86,-38.91 115.32,-34.32 119.91,-43.86 124.86,-38.91\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"126.97\" y=\"-61.17\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.19</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"126.97\" y=\"-61.17\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.18</text>\r\n",
        "</g>\r\n",
        "<!-- 4 -->\r\n",
        "<g id=\"node5\" class=\"node\">\r\n",
@@ -276,7 +276,7 @@
        "\n",
        "  </div>\n",
        "  <div>\n",
-       "    <h3 style=\"text-align: center;\">Regression-wise deletion DirectLiNGAM</h3>\n",
+       "    <h3 style=\"text-align: center;\">List-wise deletion DirectLiNGAM</h3>\n",
        "    <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
@@ -304,7 +304,7 @@
        "<title>0&#45;&gt;1</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M42.27,-105.27C52.01,-115.01 64.81,-127.81 75.79,-138.79\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"73.14,-141.09 82.68,-145.68 78.09,-136.14 73.14,-141.09\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"50.41\" y=\"-125.23\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.1</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"47.03\" y=\"-125.23\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.97</text>\r\n",
        "</g>\r\n",
        "<!-- 2 -->\r\n",
        "<g id=\"node3\" class=\"node\">\r\n",
@@ -317,7 +317,7 @@
        "<title>0&#45;&gt;2</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M54.42,-90C76.44,-90 107.63,-90 132.21,-90\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"132.16,-93.5 142.16,-90 132.16,-86.5 132.16,-93.5\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"79.07\" y=\"-93.2\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">&#45;0.04</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"79.07\" y=\"-93.2\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">&#45;0.06</text>\r\n",
        "</g>\r\n",
        "<!-- 3 -->\r\n",
        "<g id=\"node4\" class=\"node\">\r\n",
@@ -337,7 +337,7 @@
        "<title>1&#45;&gt;2</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M114.27,-146.73C124.01,-136.99 136.81,-124.19 147.79,-113.21\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"150.09,-115.86 154.68,-106.32 145.14,-110.91 150.09,-115.86\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"122.41\" y=\"-116.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.8</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"119.03\" y=\"-116.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.81</text>\r\n",
        "</g>\r\n",
        "<!-- 2&#45;&gt;3 -->\r\n",
        "<g id=\"edge5\" class=\"edge\">\r\n",
@@ -379,13 +379,13 @@
     "for i in range(n):\n",
     "    for j in range(n):\n",
     "        weightTrue = B_true[j, i]\n",
-    "        weightDL = rddl.adjacency_matrix_[j, i]\n",
+    "        weightDL = dl.adjacency_matrix_[j, i]\n",
     "        weightML = ml.adjacency_matrix_[j, i]\n",
     "        if B_true[j, i] != 0:\n",
     "            dotTrue.edge(str(i), str(j), label=str(round(weightTrue, 2)))\n",
     "        if ml.adjacency_matrix_[j, i] != 0:\n",
     "            dotML.edge(str(i), str(j), label=str(round(weightML, 2)))\n",
-    "        if rddl.adjacency_matrix_[j, i] != 0:\n",
+    "        if dl.adjacency_matrix_[j, i] != 0:\n",
     "            dotDL.edge(str(i), str(j), label=str(round(weightDL, 2)))\n",
     "\n",
     "# Add missingness mechanisms to m-LiNGAM's output\n",
@@ -412,7 +412,7 @@
     "    {svgML}\n",
     "  </div>\n",
     "  <div>\n",
-    "    <h3 style=\"text-align: center;\">Regression-wise deletion DirectLiNGAM</h3>\n",
+    "    <h3 style=\"text-align: center;\">List-wise deletion DirectLiNGAM</h3>\n",
     "    {svgDL}\n",
     "  </div>\n",
     "</div>\n",

--- a/examples/MissingnessLiNGAM.ipynb
+++ b/examples/MissingnessLiNGAM.ipynb
@@ -1,16 +1,8 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "id": "559e060a",
-   "metadata": {},
-   "source": [
-    "In this example, we need to import `numpy`, `pandas`, `graphviz`, and `IPython` in addition to `lingam`."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "cad9ee87",
    "metadata": {},
    "outputs": [
@@ -18,7 +10,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['1.26.4', '2.2.3', '0.20.3', '8.2.0', '1.10.0']\n"
+      "['2.4.2', '3.0.0', '0.21', '9.10.0', '1.12.2']\n"
      ]
     }
    ],
@@ -26,9 +18,8 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import graphviz\n",
-    "import IPython\n",
-    "from IPython.display import display, HTML\n",
     "import lingam\n",
+    "import IPython\n",
     "\n",
     "print([np.__version__, pd.__version__, graphviz.__version__, IPython.__version__, lingam.__version__])\n",
     "\n",
@@ -38,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfd35512",
+   "id": "f841fa9f",
    "metadata": {},
    "source": [
     "# Missingness-LiNGAM (m-LiNGAM)\n",
@@ -47,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52cdf6e2",
+   "id": "9d1feb55",
    "metadata": {},
    "source": [
     "First, we initialize a test grah and generate a dataset affected by missingness."
@@ -55,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "0b70fb17",
    "metadata": {},
    "outputs": [
@@ -63,13 +54,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Percentage of rows affected by missing data:  0.3558\n"
+      "Percentage of rows affected by missing data:  0.2988\n"
      ]
     }
    ],
    "source": [
-    "# Initialize the parameters\n",
-    "sample_size=5000\n",
+    "#Ex. 2 of MV-PCa\n",
+    "sample_size=50000\n",
+    "logistic_scale=1.0\n",
     "B_true = np.array([[0,0,0,0],[1.1,0,0,0],[0,0.9,0,0],[0.8,0,1.2,0]])\n",
     "\n",
     "# Generate the data\n",
@@ -77,7 +69,7 @@
     "Z = 1.1*X + np.random.laplace(size=sample_size, scale=1.0)\n",
     "Y = 0.9*Z + np.random.laplace(size=sample_size, scale=1.0)\n",
     "W = 0.8*X + 1.2*Y + np.random.laplace(size=sample_size, scale=1.0)\n",
-    "Ry = (0.5*W -1 + np.random.logistic(size=sample_size, scale=1.0))>0\n",
+    "Ry = (1.0*W -2 + np.random.logistic(size=sample_size, scale=logistic_scale))>0\n",
     "\n",
     "# Mask missing values\n",
     "Ys = Y.copy()\n",
@@ -90,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d0fa9b7",
+   "id": "e86ad509",
    "metadata": {},
    "source": [
     "Then, we run both `DirectLiNGAM` and `mLiNGAM` on the same dataset. Since DirectLiNGAM cannot handle missing values, we apply it to the dataset after removing all rows affected by missingness."
@@ -111,17 +103,9 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "c94a91e2",
-   "metadata": {},
-   "source": [
-    "We can now compare the ground truth graph, the `mLiNGAM` output graph, and the list-wise deletion `DirectLiNGAM` graph."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "7b6fc2e1",
+   "execution_count": null,
+   "id": "a9172d95",
    "metadata": {},
    "outputs": [
     {
@@ -204,7 +188,7 @@
        "<title>3&#45;&gt;4</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M126.42,-18C148.44,-18 179.63,-18 204.21,-18\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"204.16,-21.5 214.16,-18 204.16,-14.5 204.16,-21.5\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"156.69\" y=\"-21.2\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.5</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"156.69\" y=\"-21.2\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.0</text>\r\n",
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
@@ -239,7 +223,7 @@
        "<title>0&#45;&gt;1</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M42.27,-105.27C52.01,-115.01 64.81,-127.81 75.79,-138.79\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"73.14,-141.09 82.68,-145.68 78.09,-136.14 73.14,-141.09\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"47.03\" y=\"-125.23\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.11</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"50.41\" y=\"-125.23\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.1</text>\r\n",
        "</g>\r\n",
        "<!-- 3 -->\r\n",
        "<g id=\"node4\" class=\"node\">\r\n",
@@ -252,7 +236,7 @@
        "<title>0&#45;&gt;3</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M42.27,-74.73C52.01,-64.99 64.81,-52.19 75.79,-41.21\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"78.09,-43.86 82.68,-34.32 73.14,-38.91 78.09,-43.86\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"47.03\" y=\"-44.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.82</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"47.03\" y=\"-44.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.79</text>\r\n",
        "</g>\r\n",
        "<!-- 2 -->\r\n",
        "<g id=\"node3\" class=\"node\">\r\n",
@@ -265,14 +249,14 @@
        "<title>1&#45;&gt;2</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M114.27,-146.73C124.01,-136.99 136.81,-124.19 147.79,-113.21\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"150.09,-115.86 154.68,-106.32 145.14,-110.91 150.09,-115.86\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"119.03\" y=\"-116.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.87</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"119.03\" y=\"-116.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.88</text>\r\n",
        "</g>\r\n",
        "<!-- 2&#45;&gt;3 -->\r\n",
        "<g id=\"edge4\" class=\"edge\">\r\n",
        "<title>2&#45;&gt;3</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M155.73,-74.73C145.99,-64.99 133.19,-52.19 122.21,-41.21\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"124.86,-38.91 115.32,-34.32 119.91,-43.86 124.86,-38.91\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"130.34\" y=\"-61.17\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.2</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"126.97\" y=\"-61.17\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.19</text>\r\n",
        "</g>\r\n",
        "<!-- 4 -->\r\n",
        "<g id=\"node5\" class=\"node\">\r\n",
@@ -285,14 +269,14 @@
        "<title>3&#45;&gt;4</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M126.42,-18C148.44,-18 179.63,-18 204.21,-18\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"204.16,-21.5 214.16,-18 204.16,-14.5 204.16,-21.5\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"153.32\" y=\"-21.2\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.49</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"153.32\" y=\"-21.2\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.99</text>\r\n",
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
        "\n",
        "  </div>\n",
        "  <div>\n",
-       "    <h3 style=\"text-align: center;\">List-wise deletion DirectLiNGAM</h3>\n",
+       "    <h3 style=\"text-align: center;\">Regression-wise deletion DirectLiNGAM</h3>\n",
        "    <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
@@ -320,7 +304,20 @@
        "<title>0&#45;&gt;1</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M42.27,-105.27C52.01,-115.01 64.81,-127.81 75.79,-138.79\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"73.14,-141.09 82.68,-145.68 78.09,-136.14 73.14,-141.09\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"47.03\" y=\"-125.23\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.03</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"50.41\" y=\"-125.23\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.1</text>\r\n",
+       "</g>\r\n",
+       "<!-- 2 -->\r\n",
+       "<g id=\"node3\" class=\"node\">\r\n",
+       "<title>2</title>\r\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"171\" cy=\"-90\" rx=\"27\" ry=\"18\"/>\r\n",
+       "<text text-anchor=\"middle\" x=\"171\" y=\"-84.95\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">Y</text>\r\n",
+       "</g>\r\n",
+       "<!-- 0&#45;&gt;2 -->\r\n",
+       "<g id=\"edge2\" class=\"edge\">\r\n",
+       "<title>0&#45;&gt;2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M54.42,-90C76.44,-90 107.63,-90 132.21,-90\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"132.16,-93.5 142.16,-90 132.16,-86.5 132.16,-93.5\"/>\r\n",
+       "<text text-anchor=\"middle\" x=\"79.07\" y=\"-93.2\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">&#45;0.04</text>\r\n",
        "</g>\r\n",
        "<!-- 3 -->\r\n",
        "<g id=\"node4\" class=\"node\">\r\n",
@@ -329,31 +326,25 @@
        "<text text-anchor=\"middle\" x=\"99\" y=\"-12.95\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">W</text>\r\n",
        "</g>\r\n",
        "<!-- 0&#45;&gt;3 -->\r\n",
-       "<g id=\"edge2\" class=\"edge\">\r\n",
+       "<g id=\"edge3\" class=\"edge\">\r\n",
        "<title>0&#45;&gt;3</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M42.27,-74.73C52.01,-64.99 64.81,-52.19 75.79,-41.21\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"78.09,-43.86 82.68,-34.32 73.14,-38.91 78.09,-43.86\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"47.03\" y=\"-44.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.77</text>\r\n",
-       "</g>\r\n",
-       "<!-- 2 -->\r\n",
-       "<g id=\"node3\" class=\"node\">\r\n",
-       "<title>2</title>\r\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"171\" cy=\"-90\" rx=\"27\" ry=\"18\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"171\" y=\"-84.95\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">Y</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"47.03\" y=\"-44.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.75</text>\r\n",
        "</g>\r\n",
        "<!-- 1&#45;&gt;2 -->\r\n",
-       "<g id=\"edge3\" class=\"edge\">\r\n",
+       "<g id=\"edge4\" class=\"edge\">\r\n",
        "<title>1&#45;&gt;2</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M114.27,-146.73C124.01,-136.99 136.81,-124.19 147.79,-113.21\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"150.09,-115.86 154.68,-106.32 145.14,-110.91 150.09,-115.86\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"119.03\" y=\"-116.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.81</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"122.41\" y=\"-116.67\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">0.8</text>\r\n",
        "</g>\r\n",
        "<!-- 2&#45;&gt;3 -->\r\n",
-       "<g id=\"edge4\" class=\"edge\">\r\n",
+       "<g id=\"edge5\" class=\"edge\">\r\n",
        "<title>2&#45;&gt;3</title>\r\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M155.73,-74.73C145.99,-64.99 133.19,-52.19 122.21,-41.21\"/>\r\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"124.86,-38.91 115.32,-34.32 119.91,-43.86 124.86,-38.91\"/>\r\n",
-       "<text text-anchor=\"middle\" x=\"126.97\" y=\"-61.17\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.13</text>\r\n",
+       "<text text-anchor=\"middle\" x=\"130.34\" y=\"-61.17\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">1.1</text>\r\n",
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
@@ -388,19 +379,19 @@
     "for i in range(n):\n",
     "    for j in range(n):\n",
     "        weightTrue = B_true[j, i]\n",
-    "        weightDL = dl.adjacency_matrix_[j, i]\n",
+    "        weightDL = rddl.adjacency_matrix_[j, i]\n",
     "        weightML = ml.adjacency_matrix_[j, i]\n",
     "        if B_true[j, i] != 0:\n",
     "            dotTrue.edge(str(i), str(j), label=str(round(weightTrue, 2)))\n",
     "        if ml.adjacency_matrix_[j, i] != 0:\n",
     "            dotML.edge(str(i), str(j), label=str(round(weightML, 2)))\n",
-    "        if dl.adjacency_matrix_[j, i] != 0:\n",
+    "        if rddl.adjacency_matrix_[j, i] != 0:\n",
     "            dotDL.edge(str(i), str(j), label=str(round(weightDL, 2)))\n",
     "\n",
     "# Add missingness mechanisms to m-LiNGAM's output\n",
     "dotML.node('4', 'Ry', pos='3,0!')\n",
     "dotTrue.node('4', 'Ry', pos='3,0!')\n",
-    "dotTrue.edge('3', '4', label=str(0.5))\n",
+    "dotTrue.edge('3', '4', label=str(1.0))\n",
     "for k,missigness_parent in enumerate(ml._missingness_mechanisms_parents[2]):\n",
     "    dotML.edge(str(missigness_parent), '4', label=str(round(ml._missingness_mechanisms_coef[2][k+1], 2)))\n",
     "\n",
@@ -421,7 +412,7 @@
     "    {svgML}\n",
     "  </div>\n",
     "  <div>\n",
-    "    <h3 style=\"text-align: center;\">List-wise deletion DirectLiNGAM</h3>\n",
+    "    <h3 style=\"text-align: center;\">Regression-wise deletion DirectLiNGAM</h3>\n",
     "    {svgDL}\n",
     "  </div>\n",
     "</div>\n",
@@ -432,7 +423,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57849ac4",
+   "id": "f08fd54b",
    "metadata": {},
    "source": [
     "As expected, while naively applying `DirectLiNGAM` to the list-wise deleted dataset produce extraneous edges and biased estimates for the parameters, `mLiNGAM` is able to produce a more accurate estimate of both the graph structure and the parameters. Note that `mLiNGAM` also reconstructs the missingness mechanism that led to missingness, correctly identyfing that the data was missing at random with $W$ as parent of $R_Y$, the missingness mechanism corresponding to variable $Y$."
@@ -441,7 +432,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -455,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/examples/MissingnessLiNGAM.ipynb
+++ b/examples/MissingnessLiNGAM.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "cad9ee87",
    "metadata": {},
    "outputs": [
@@ -10,7 +10,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['2.4.2', '3.0.0', '0.21', '9.10.0', '1.12.2']\n"
+      "['1.26.1', '2.1.2', '0.20.1', '1.12.2']\n"
      ]
     }
    ],
@@ -19,9 +19,9 @@
     "import pandas as pd\n",
     "import graphviz\n",
     "import lingam\n",
-    "import IPython\n",
+    "from IPython.display import display, HTML\n",
     "\n",
-    "print([np.__version__, pd.__version__, graphviz.__version__, IPython.__version__, lingam.__version__])\n",
+    "print([np.__version__, pd.__version__, graphviz.__version__, lingam.__version__])\n",
     "\n",
     "np.set_printoptions(precision=3, suppress=True)\n",
     "np.random.seed(100)"
@@ -432,7 +432,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/lingam/missingness_lingam.py
+++ b/lingam/missingness_lingam.py
@@ -8,6 +8,7 @@ import statsmodels.api as sm
 from sklearn.utils import check_array
 from sklearn.preprocessing import StandardScaler
 from sklearn.linear_model import LinearRegression, LogisticRegression, Lasso, LassoLarsIC
+import itertools
 
 from .base import _BaseLiNGAM
 from .utils import bic_select_logistic_l1
@@ -141,7 +142,7 @@ class mLiNGAM(_BaseLiNGAM):
 
             if len(self._missingness_mechanisms_parents[k]) == 0:
                 clf = LogisticRegression(
-                    penalty=None,
+                    C=np.inf,
                     solver='lbfgs',
                     max_iter=1000,
                     fit_intercept=False
@@ -151,7 +152,6 @@ class mLiNGAM(_BaseLiNGAM):
                 self._missingness_mechanisms_coef[k] = np.concatenate([clf.coef_.ravel()])
             else:
                 clf = LogisticRegression(
-                    penalty='l2',
                     C=0.5,
                     solver='lbfgs',
                     max_iter=1000,

--- a/lingam/missingness_lingam.py
+++ b/lingam/missingness_lingam.py
@@ -99,16 +99,44 @@ class mLiNGAM(_BaseLiNGAM):
         R = {i : missing_mask[:, i] for i in missing_column_indices}
         for k in R.keys():
             # Find the parent nodes of the missingness mechanism
-            available_rows = ~np.any(np.isnan(np.delete(X_, k, axis=1)), axis=1)
+            all_features = [i for i in range(self.n_features) if i != k]
 
-            X_lreg = np.delete(X_, k, axis=1)[available_rows]
-            scaler = StandardScaler()
-            X_lreg = scaler.fit_transform(X_lreg)
+            available_rows = ~np.any(np.isnan(X_[:, all_features]), axis=1)
 
-            best_coef, _, _, _, _ = bic_select_logistic_l1(X_lreg, R[k][available_rows], Cs=50, max_iter=1000)
+            # If there are no complete samples to be used for the logistic regression 
+            # try removing as few features with missing data as possible
+            if np.unique(R[k][available_rows]).size < 2:
+              missing_cols = [i for i in missing_column_indices if i != k]
+              non_missing_cols = [i for i in all_features if i not in missing_cols]
 
-            self._missingness_mechanisms_parents[k] = list(np.arange(self.n_features)[np.where(best_coef != 0)])
-            self._missingness_mechanisms_parents[k] = [idx if idx < k else idx + 1 for idx in self._missingness_mechanisms_parents[k]]
+              best_subset = ()
+
+              for size in range(len(missing_cols)-1, -1, -1):
+                  for comb in itertools.combinations(missing_cols, size):
+                      current_subset = non_missing_cols + list(comb)
+
+                      available_rows = ~np.any(np.isnan(X_[:, current_subset]), axis=1)
+
+                      if np.unique(R[k][available_rows]).size >= 2:
+                          best_subset = current_subset
+                          break
+                  if len(best_subset) > 0:
+                      break
+            else:
+              best_subset = all_features
+
+            if len(best_subset)>0:
+                X_lreg = X_[:,sorted(best_subset)][available_rows]
+                scaler = StandardScaler()
+                X_lreg = scaler.fit_transform(X_lreg)
+
+                best_coef, _, _, _, _ = bic_select_logistic_l1(X_lreg, R[k][available_rows], Cs=50, max_iter=1000)
+
+                selected_idx = np.where(best_coef != 0)[0]
+                self._missingness_mechanisms_parents[k] = [best_subset[i] for i in selected_idx]
+            else:
+                self._missingness_mechanisms_parents[k] = []
+
             available_rows = ~np.any(np.isnan(X_[:, self._missingness_mechanisms_parents[k]]), axis=1)
 
             if len(self._missingness_mechanisms_parents[k]) == 0:
@@ -118,7 +146,6 @@ class mLiNGAM(_BaseLiNGAM):
                     max_iter=1000,
                     fit_intercept=False
                 )
-                # independent_vars = np.ones_like(R[k])
                 independent_vars = np.ones_like(R[k]).reshape(-1, 1)
                 clf.fit(independent_vars, R[k][available_rows])
                 self._missingness_mechanisms_coef[k] = np.concatenate([clf.coef_.ravel()])

--- a/lingam/missingness_lingam.py
+++ b/lingam/missingness_lingam.py
@@ -153,6 +153,7 @@ class mLiNGAM(_BaseLiNGAM):
             else:
                 clf = LogisticRegression(
                     C=0.5,
+                    l1_ratio=0,
                     solver='lbfgs',
                     max_iter=1000,
                     fit_intercept=True
@@ -165,7 +166,7 @@ class mLiNGAM(_BaseLiNGAM):
         X_top = X_.copy()
 
         for _ in range(len(U)):
-            m = self._search_causal_order_top_down(X_top, U, min_samples=self.n_features + 1)
+            m = self._search_causal_order_top_down(X_top, U)
             for i in U:
                 if i != m:
                     X_top[:, i][~np.isnan(X[:, [i, m]]).any(axis=1)] = self._residual(X_top[:, i][~np.isnan(X[:, [i, m]]).any(axis=1)], X_top[:, m][~np.isnan(X[:, [i, m]]).any(axis=1)])
@@ -228,7 +229,6 @@ class mLiNGAM(_BaseLiNGAM):
                         # Correction reduces the sample size, if samples < features try Adaptive Lasso again w/o correction
                         involved_variables = [target] + predictors
                         X_m = X[~np.any(np.isnan(X[:, involved_variables]), axis=1)]
-                        print("c ",X_m.shape, len(involved_variables))#
                         
                         X_std = scaler.fit_transform(X_m)
 
@@ -376,7 +376,7 @@ class mLiNGAM(_BaseLiNGAM):
                 Vj.append(i)
         return Uc, Vj
 
-    def _search_causal_order_top_down(self, X, U, min_samples=0):
+    def _search_causal_order_top_down(self, X, U):
         """Search the causal ordering from top to bottom."""
         Uc, Vj = self._search_candidate_top_down(U)
         if len(Uc) == 1:
@@ -389,8 +389,6 @@ class mLiNGAM(_BaseLiNGAM):
                 if i != j:
                     X_m = X[:, [i, j]].copy()
                     X_m = X_m[~np.isnan(X_m).any(axis=1)]
-                    if X_m.shape[0] < min_samples:
-                        return -1
                     xi_std = (X_m[:, 0] - np.mean(X_m[:, 0])) / np.std(X_m[:, 0])
                     xj_std = (X_m[:, 1] - np.mean(X_m[:, 1])) / np.std(X_m[:, 1])
                     ri_j = (

--- a/lingam/missingness_lingam.py
+++ b/lingam/missingness_lingam.py
@@ -216,10 +216,29 @@ class mLiNGAM(_BaseLiNGAM):
 
                 # Pruning with Adaptive Lasso
                 lr = Lasso(alpha=0.1)
-                lr.fit(X_std[:, predictors], X_std[:, target], sample_weight=sample_weight)
-                weight = np.power(np.abs(lr.coef_), 1.0)
-                reg = LassoLarsIC(criterion="bic")
-                reg.fit(X_std[:, predictors] * weight, X_std[:, target])
+
+                try:
+                    lr.fit(X_std[:, predictors], X_std[:, target], sample_weight=sample_weight)
+                    weight = np.power(np.abs(lr.coef_), 1.0)
+                    reg = LassoLarsIC(criterion="bic")
+                    reg.fit(X_std[:, predictors] * weight, X_std[:, target])
+                except ValueError as e:
+                    msg = "You are using LassoLarsIC in the case where the number of samples is smaller than the number of features"
+                    if msg in str(e):
+                        # Correction reduces the sample size, if samples < features try Adaptive Lasso again w/o correction
+                        involved_variables = [target] + predictors
+                        X_m = X[~np.any(np.isnan(X[:, involved_variables]), axis=1)]
+                        print("c ",X_m.shape, len(involved_variables))#
+                        
+                        X_std = scaler.fit_transform(X_m)
+
+                        lr.fit(X_std[:, predictors], X_std[:, target])
+                        weight = np.power(np.abs(lr.coef_), 1.0)
+                        reg = LassoLarsIC(criterion="bic")
+                        reg.fit(X_std[:, predictors] * weight, X_std[:, target])
+                    else:
+                        raise
+                    
                 pruned_idx = np.abs(reg.coef_ * weight) > 0.0
 
                 pred = np.array(predictors)

--- a/lingam/utils/__init__.py
+++ b/lingam/utils/__init__.py
@@ -1191,6 +1191,7 @@ def bic_select_logistic_l1(X, y, Cs=50, max_iter=1000):
     """
     coefs, Cs, _ = _logistic_regression_path(
         X, y,
+        classes=np.unique(y),
         penalty='l1',
         solver='saga',
         fit_intercept=True,

--- a/lingam/utils/__init__.py
+++ b/lingam/utils/__init__.py
@@ -1192,7 +1192,7 @@ def bic_select_logistic_l1(X, y, Cs=50, max_iter=1000):
     coefs, Cs, _ = _logistic_regression_path(
         X, y,
         classes=np.unique(y),
-        penalty='l1',
+        l1_ratio=1.,
         solver='saga',
         fit_intercept=True,
         max_iter=max_iter,


### PR DESCRIPTION
Good day,

While experimenting with m-LiNGAM, we observed that with small sample sizes and high percentages of missing data, logistic regression can fail when identifying the causes of missingness.

This update introduces a mechanism to increase sample availability in such cases by removing a minimal set of potential parent variables that are partially observed.  Similarly, if there are not enough datapoints for the adaptive Lasso procedure (samples < features), the algorithm now attempts the procedure without bias correction (as bias correction reduces the number of available samples). Both procedures preserve the sample-limit properties as they are never executed for large enough samples, while allowing the execution on small datasets with substantial missing data.

Additionally, we:

- Fixed invalid symbols in the documentation and highlighted the code example.
- Improved the tutorial example by correcting a label and choosing a more illustrative case.
- Removed the deprecated penalty argument from the sklearn logistic regression calls to suppress warnings and avoid deprecation.

Please let me know if you have any questions or need further changes.

Best regards,
Matteo Ceriscioli